### PR TITLE
⬆️  修复client无法通过run test的问题

### DIFF
--- a/client/src/grpc.rs
+++ b/client/src/grpc.rs
@@ -33,7 +33,7 @@ pub async fn report(args: &Args, stat_base: &mut StatRequest) -> anyhow::Result<
         );
     }
 
-    let token = MetadataValue::from_str(format!("{}@_@{}", args.user, args.pass).as_str())?;
+    let token = MetadataValue::try_from(format!("{}@_@{}", args.user, args.pass).as_str())?;
 
     let channel = Channel::from_shared(args.addr.to_string())?
         .connect()


### PR DESCRIPTION
在github action 构建时，每次都卡在Run Tests，查看报错信息得知client/src/grpc中MetadataValue ::from_str方法已被弃用，根据提示换成try_from通过构建流程