### PR TITLE
compatible with both vnstat 1.x and 2.x

### DIFF
--- a/client/src/status.rs
+++ b/client/src/status.rs
@@ -112,8 +112,11 @@ pub fn get_vnstat_traffic(args: &Args) -> (u64, u64, u64, u64) {
         .stdout;
     let b = str::from_utf8(&a).unwrap();
     let j: HashMap<&str, serde_json::Value> = serde_json::from_str(b).unwrap();
+    let json_version = j["jsonversion"].as_str().unwrap();
     for iface in j["interfaces"].as_array().unwrap() {
-        let name = iface["name"].as_str().unwrap();
+        let name = if json_version == "1" { iface["id"].as_str().unwrap() } else { iface["name"].as_str().unwrap() };
+        let month_field = if json_version == "1" { "months" } else { "month" };
+        let bandwith_factor: u64 = if json_version == "1" { 1024 } else { 1 };
 
         // spec iface
         if skip_iface(name, args) {
@@ -121,9 +124,9 @@ pub fn get_vnstat_traffic(args: &Args) -> (u64, u64, u64, u64) {
         }
 
         let total_o = iface["traffic"]["total"].as_object().unwrap();
-        let month_v = iface["traffic"]["month"].as_array().unwrap();
-        network_in += total_o["rx"].as_u64().unwrap();
-        network_out += total_o["tx"].as_u64().unwrap();
+        let month_v = iface["traffic"][month_field].as_array().unwrap();
+        network_in += total_o["rx"].as_u64().unwrap() * bandwith_factor;
+        network_out += total_o["tx"].as_u64().unwrap() * bandwith_factor;
 
         for data in month_v {
             let year = data["date"]["year"].as_i64().unwrap() as i32;
@@ -132,8 +135,8 @@ pub fn get_vnstat_traffic(args: &Args) -> (u64, u64, u64, u64) {
                 continue;
             }
 
-            m_network_in += data["rx"].as_u64().unwrap();
-            m_network_out += data["tx"].as_u64().unwrap();
+            m_network_in += data["rx"].as_u64().unwrap() * bandwith_factor;
+            m_network_out += data["tx"].as_u64().unwrap() * bandwith_factor;
         }
     }
 


### PR DESCRIPTION
Currently, the client only parses jsonversion 2 of vnstat which is only possible with vnstat 2.x.

This patch brings support for old vnstat 1.x format.