### PR TITLE
Python Client: int(get_cpu()) to make CPU percent an integer

### DIFF
--- a/client/stat_client.py
+++ b/client/stat_client.py
@@ -283,7 +283,7 @@ def byte_str(object):
 
 
 def sample(options, stat_base):
-    cpu_percent = get_cpu()
+    cpu_percent = int(get_cpu())
     uptime = get_uptime()
     load_1, load_5, load_15 = os.getloadavg(
     ) if 'linux' in sys.platform else (0.0, 0.0, 0.0)


### PR DESCRIPTION
现在Python客户端的CPU占用率是小数，而原版客户端是整数。故将二者设为一致。