### PR TITLE
feat(email): 新增可选的 `from` 字段用于设置发件地址

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -117,6 +117,10 @@ custom_tpl = """
 [email]
 enabled = false
 server = "smtp.gmail.com"
+# 可选：发件人邮箱地址。
+# 部分服务商（如 SendGrid）SMTP 登录账号(username)为 API Key 而非邮箱地址，
+# 此时需在此填写真实发件邮箱；留空则默认使用 username 作为发件地址。
+#from = "user@email.com"
 username = "user@email.com"
 password = "***"
 to = "user1@email.com;user2@email.com"

--- a/server/src/notifier/email.rs
+++ b/server/src/notifier/email.rs
@@ -20,6 +20,7 @@ pub struct Config {
     pub server: String,
     pub username: String,
     pub password: String,
+    pub from: Option<String>,
     pub to: String,
     pub subject: String,
     pub title: String,
@@ -48,9 +49,10 @@ impl crate::notifier::Notifier for Email {
     }
 
     fn send_notify(&self, html_content: String) -> Result<()> {
+        let from_addr = self.config.from.as_deref().unwrap_or(&self.config.username);
         let mut builder = Message::builder()
             .subject(self.config.subject.clone())
-            .from(format!("ServerStatus <{}>", self.config.username).parse().unwrap());
+            .from(format!("ServerStatus <{from_addr}>").parse().unwrap());
 
         let mailboxes: Mailboxes = self.config.to.parse().expect("Invalid email addresses");
         for mailbox in mailboxes.iter() {


### PR DESCRIPTION
部分邮件服务商（如 SendGrid）的 SMTP 登录账号使用 API Key，
与实际的发件邮箱地址不同，因此需要单独配置发件人。
新增可选的 `from` 字段，未指定时回退使用 `username` 作为发件地址。